### PR TITLE
fix cli install path

### DIFF
--- a/content/en/jmap/get-started/docker.md
+++ b/content/en/jmap/get-started/docker.md
@@ -63,7 +63,7 @@ is running or any other computer with internet access to your server:
 - **Linux / MacOS**: 
 
     ```bash
-    curl --proto '=https' --tlsv1.2 -sSf https://jmap-cli.stalw.art/install.sh | sh
+    curl --proto '=https' --tlsv1.2 -sSf https://cli.stalw.art/install.sh | sh
     ```
     Once the installation is completed, the CLI tool will be available in your home directory at ``$HOME/.stalwart/stalwart-cli``. You may add the
     ``$HOME/.stalwart`` directory to your ``PATH`` environment variable or move the ``stalwart-cli`` binary to a location that is already

--- a/content/en/smtp/get-started/docker.md
+++ b/content/en/smtp/get-started/docker.md
@@ -65,7 +65,7 @@ is running or any other computer with internet access to your server:
 - **Linux / MacOS**: 
 
     ```bash
-    curl --proto '=https' --tlsv1.2 -sSf https://smtp-cli.stalw.art/install.sh | sh
+    curl --proto '=https' --tlsv1.2 -sSf https://cli.stalw.art/install.sh | sh
     ```
     Once the installation is completed, the CLI tool will be available in your home directory at ``$HOME/.stalwart/stalwart-cli``. You may add the
     ``$HOME/.stalwart`` directory to your ``PATH`` environment variable or move the ``stalwart-cli`` binary to a location that is already


### PR DESCRIPTION
## Summary

Docker sections for JMAP / SMTP refer to hosts jmap-cli.stalw.art / smtp-cli.stalw.art, which seem to be outdated.
Replace with cli.stalw.art